### PR TITLE
recursively look for .readthedocs-custom-steps.yml so it can be outside top-level root

### DIFF
--- a/readthedocs-custom-steps/src/readthedocs_custom_steps.py
+++ b/readthedocs-custom-steps/src/readthedocs_custom_steps.py
@@ -29,8 +29,25 @@ def main():
     print('readthedocs-custom-steps', __version__)
     return
 
-  filename = '.readthedocs-custom-steps.yml'
-  if os.path.isfile(filename):
+  def recursive_find_filename(fname, directory='.'):
+    for current_path, directories, files in os.walk(directory):
+      if os.path.split(current_path)[-1] == 'test':
+        continue
+      elif fname in files:
+        return os.path.join(directory, fname)
+      elif directories == '':
+        return None
+      else:
+        for next_directory in directories:
+          result = recursive_find_filename(directory=os.path.join(directory, next_directory), fname=fname)
+          if result:
+            return result
+        return None
+
+  filename = recursive_find_filename('.readthedocs-custom-steps.yml')
+  print('readthedocs-custom-steps config = {}'.format(filename), file=sys.stderr)
+
+  if filename and os.path.isfile(filename):
     with open(filename) as fp:
       steps = yaml.safe_load(fp)['steps']
   else:


### PR DESCRIPTION
Implements a recursive search for `.readthedocs-custom-steps.yml` thus allowing this file to exist outside of the top-level root.

This hence allows _all_ the documentation configuration files exist outside of the root and together in a `/docs/` path for example -
* in the file `.readthedocs.yml` we point to `requirements: docs/.readthedocs-requirements.txt`
* we invoke `pydoc-markdown` via `.readthedocs-custom-steps.yml` by naming the config file `pydoc-markdown --build --site-dir $SITE_DIR -vv docs/pydoc-markdown.yml`
